### PR TITLE
Take multiple quotes

### DIFF
--- a/cogs/bible.py
+++ b/cogs/bible.py
@@ -7,7 +7,6 @@ import discord
 from discord.ext import commands
 from discord import app_commands
 from discord import app_commands, AllowedMentions
-import datetime
 from datetime import datetime, timezone, timedelta
 import random
 import json
@@ -114,9 +113,10 @@ class bible(commands.Cog):
         else:       
             selected_msg = random.choice(msg_table)
 
-        match = re.search(r'''["](.+?)["]''', selected_msg.content) #Search for the quoted content
-        extracted_quote = match.group(1).strip() if match else selected_msg.content.strip() #Strip everything that isn't the quoted content
-        formatted_quote = f'"{extracted_quote}"' #Format the quoted content into quotations
+        all_matches = re.findall(r'''["](.+?)["]''', selected_msg.content)
+        
+        extracted_quote = '"\n"'.join(match.strip() for match in all_matches)
+        formatted_quote = f'"{extracted_quote}"'
 
         embed = discord.Embed(
             title="✝️ Bible Quote", 

--- a/cogs/bible_daily.py
+++ b/cogs/bible_daily.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 import discord
-import datetime
+from datetime import datetime, time, timezone, timedelta
 from discord.ext import tasks, commands
 from discord import AllowedMentions
 import json
@@ -61,44 +61,54 @@ class bible_daily(commands.Cog):
             self.daily_bible_quote.cancel()
 
 
-        @tasks.loop(time=datetime.time(hour=16, minute=00, tzinfo=datetime.timezone.utc)) #Convert UTC to EST, so this should send at 12pm every day.
+        @tasks.loop(time=time(hour=16, minute=00, tzinfo=timezone.utc)) #Convert UTC to EST, so this should send at 12pm every day.
         async def daily_bible_quote(self):
             await self.bot.wait_until_ready()
 
+            based_chat_channel = self.bot.get_channel(self.settings_data.get("based_chat_channel_id"))
             ooc_channel_id = self.settings_data.get("out_of_context_channel_id")
-            based_chat_channel_id = self.settings_data.get("based_chat_channel_id")
-
             ooc_channel = self.bot.get_channel(ooc_channel_id)
-            based_chat_channel = self.bot.get_channel(based_chat_channel_id)
-
             random_gospel = random.choice(self.gospels_data)
             random_opener = random.choice(self.openers_data)
-            fetch_limit = 100 # Going too far back would be resource intensive.
+
+            # A date relatively close, but not too close, to the first OOC message.
+            old_date = datetime(2022, 3, 14, 0, 0, 0, tzinfo=timezone.utc) 
+
+            #Timezone declaration necessary to make this datetime object an 'aware' one.
+            current_date = datetime.now(timezone.utc)
+
+            num_days = current_date - old_date 
+
+            random_date = current_date - timedelta(days=random.randint(1, num_days.days)) #This selects the random date.
 
             msg_table = [
-                msg async for msg in ooc_channel.history(limit=fetch_limit)
-                if not msg.author.bot # Not from a bot
-                and ( # Start of combined OR condition
-                    (msg.content and ( # Message has text AND CONTAINS a quoted string
-                        re.search(r'''["](.+?)["]''', msg.content) # Checks if content CONTAINS "..."
+                msg async for msg in ooc_channel.history(limit=75, around=random_date)
+                if not msg.author.bot
+                and ( 
+                    (msg.content and (
+                        re.search(r'''["](.+?)["]''', msg.content)
                     ))
                 )
             ]
 
-            selected_msg = random.choice(msg_table)
+            # If a situation were to ever somehow occur where msg_table comes empty, use a pre-selected message to keep things moving.
+            if not msg_table:
+                selected_msg = await ooc_channel.fetch_message(1426039544490229811)
+            else:       
+                selected_msg = random.choice(msg_table)
 
-            match = re.search(r'''["](.+?)["]''', selected_msg.content) #Search for the quoted content
-            extracted_quote = match.group(1).strip() if match else selected_msg.content.strip() #Strip everything that isn't the quoted content
-            formatted_quote = f'"{extracted_quote}"' #Format the quoted content into quotations
+            all_matches = re.findall(r'''["](.+?)["]''', selected_msg.content)
+            
+            extracted_quote = '"\n"'.join(match.strip() for match in all_matches)
+            formatted_quote = f'"{extracted_quote}"'
 
             embed = discord.Embed(
-                title="✝️ Bible Quote of the Day", 
+                title="", 
                 description=f"{formatted_quote}\n\n —**{random_gospel}**",
                 color=discord.Color.purple()
-            )
+                )
             embed.set_footer(text="This quote is not representative of the Endurance Coalition's values.")
-
-            await based_chat_channel.send(content=random_opener, embed=embed)     
+            await based_chat_channel.send(content=f"# ✝️ Bible Quote of the Day\n\n:palms_up_together: {random_opener}", embed=embed)
 
         @daily_bible_quote.before_loop
         async def before_daily_bible_quote(self):


### PR DESCRIPTION
`/bibleq` will not properly detect if multiple quotes exist in a single message, grab them all out, and format them to be line-by-line. 

Also:
- Applied logic changes from #26 to the daily bible quote function.
- Changed the display of the daily bible quote to make it more unique than when a quote is generated manually. 

Closes #7 