### PR TITLE
Rquote and daily bible now display images

### DIFF
--- a/cogs/bible_daily.py
+++ b/cogs/bible_daily.py
@@ -90,6 +90,10 @@ class bible_daily(commands.Cog):
             color=discord.Color.purple()
             )
         embed.set_footer(text="This quote is not representative of the Endurance Coalition's values.")
+        
+        if selected_msg.attachments:
+            embed.set_image(url=selected_msg.attachments[0].url)
+
         await based_chat_channel.send(content=f"# ✝️ Bible Quote of the Day\n\n:palms_up_together: {random_opener}", embed=embed)
 
     @daily_bible_quote.before_loop

--- a/cogs/rquote.py
+++ b/cogs/rquote.py
@@ -120,6 +120,10 @@ class rquote(commands.Cog):
             )
         
         embed.set_footer(text="This scenario is not representative of the Endurance Coalition's values.")
+
+        if selected_msg.attachments:
+            embed.set_image(url=selected_msg.attachments[0].url)
+
         await interaction.response.send_message(embed=embed)
 
     @rquote.error


### PR DESCRIPTION
Wow. This was, uh, much simpler than I thought it'd be. Not that I'm complaining...

If a message selected by `/rquote` or the daily bible quote function has an _attachment_, it will now be displayed. I have tested this against various formats and, due to how Discord embeds function, because the URL is being parsed into `set_image`, it isn't possible for anything other than an image to be displayed. Which I suppose is good.

I am unsure if Discord provides sufficient functionality for `/rquote` to work with videos. I'm leaning "no", personally.

Closes #40 