### PR TITLE
JSON loading centralized, daily bibleq execution made a configuration

### DIFF
--- a/cogs/bible_daily.py
+++ b/cogs/bible_daily.py
@@ -1,54 +1,26 @@
-import os
-from dotenv import load_dotenv
-
-load_dotenv()
-
 import discord
 from datetime import datetime, time, timezone, timedelta
 from discord.ext import tasks, commands
-import json
 import logging
 import random
 import re
+from config_loader import SETTINGS_DATA, MISC_DATA
 
 logger = logging.getLogger('discord')
 logger.setLevel(logging.INFO)
-
-GUILD_ID = int(os.getenv('guild'))
-
-VARIABLES_FILE = "data/variables.json"
-MISC_FILE = "data/misc_text.json"
 
 class bible_daily(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.daily_bible_quote.start()
-        self.variables_file = {}
-
-        try:
-            with open(VARIABLES_FILE, 'r', encoding='utf-8') as file_object:
-                self.settings_data = json.load(file_object)
-                logger.info(f"[{self.__class__.__name__}] Successfully loaded settings from {VARIABLES_FILE}")
-        
-        except FileNotFoundError:
-            logger.critical(f"[{self.__class__.__name__}] FATAL ERROR: {VARIABLES_FILE} not found.")
-            return
-        
-        try:
-            with open(MISC_FILE, 'r') as file_object:
-                self.misc_data = json.load(file_object)
-                logger.info(f"[{self.__class__.__name__}] Successfully loaded miscellaneous text from {MISC_FILE}")
-        
-        except FileNotFoundError:
-            logger.critical(f"[{self.__class__.__name__}] FATAL ERROR: {MISC_FILE} not found.")
-            return
-
+        self.settings_data = SETTINGS_DATA
+        self.misc_data = MISC_DATA
 
     def cog_unload(self):
         self.daily_bible_quote.cancel()
 
 
-    @tasks.loop(time=time(hour=16, minute=00, tzinfo=timezone.utc)) #Convert UTC to EST, so this should send at 12pm every day.
+    @tasks.loop(time=time(hour=SETTINGS_DATA["bibleq_hour_of_day"], minute=SETTINGS_DATA["bibleq_min_of_day"], tzinfo=timezone.utc)) #Convert UTC to EST, so this should send at 12pm every day.
     async def daily_bible_quote(self):
         await self.bot.wait_until_ready()
 

--- a/cogs/bot_react.py
+++ b/cogs/bot_react.py
@@ -1,54 +1,23 @@
-import os
-from dotenv import load_dotenv
-
-load_dotenv()
-
 import discord
 from discord.ext import commands
-from discord import app_commands
-from discord import app_commands, AllowedMentions
-import random
-import json
-import re
+from discord import AllowedMentions
 import logging
+from config_loader import SETTINGS_DATA, MISC_DATA
 
 logger = logging.getLogger('discord')
 logger.setLevel(logging.DEBUG)
 
-GUILD_ID = int(os.getenv('guild'))
-
-VARIABLES_FILE = "data/variables.json"
-MISC_FILE = "data/misc_text.json"
-
 class bot_react(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.variables_file = {}
+        self.settings_data = SETTINGS_DATA
+        self.misc_data = MISC_DATA        
     
         self.default_allowed_mentions = AllowedMentions(
                 everyone=False,
                 users=True, 
                 roles=True      
             )
-        
-        try:
-            with open(VARIABLES_FILE, 'r', encoding='utf-8') as file_object:
-                self.settings_data = json.load(file_object)
-                logger.info(f"[{self.__class__.__name__}] Successfully loaded settings from {VARIABLES_FILE}")
-        
-        except FileNotFoundError:
-            logger.critical(f"[{self.__class__.__name__}] FATAL ERROR: {VARIABLES_FILE} not found.")
-            return
-        
-        try:
-            with open(MISC_FILE, 'r') as file_object:
-                self.misc_data = json.load(file_object)
-                logger.info(f"[{self.__class__.__name__}] Successfully loaded miscellaneous text from {MISC_FILE}")
-        
-        except FileNotFoundError:
-            logger.critical(f"[{self.__class__.__name__}] FATAL ERROR: {MISC_FILE} not found.")
-            return
-
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):

--- a/cogs/manage_role.py
+++ b/cogs/manage_role.py
@@ -7,38 +7,24 @@ import discord
 from discord.ext import commands
 from discord import app_commands
 from discord import app_commands, AllowedMentions
-import random
-import json
-import re
 import logging
+from config_loader import SETTINGS_DATA
 
 logger = logging.getLogger('discord')
 logger.setLevel(logging.INFO)
 
 GUILD_ID = int(os.getenv('guild'))
 
-VARIABLES_FILE = "data/variables.json"
-
 class manage_role(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.variables_file = {}
+        self.settings_data = SETTINGS_DATA
     
         self.default_allowed_mentions = AllowedMentions(
                 everyone=False,
                 users=True, 
                 roles=True      
             )
-
-        try:
-            with open(VARIABLES_FILE, 'r', encoding='utf-8') as file_object:
-                self.settings_data = json.load(file_object)
-                logger.info(f"[{self.__class__.__name__}] Successfully loaded settings from {VARIABLES_FILE}")
-        
-        except FileNotFoundError:
-            logger.critical(f"[{self.__class__.__name__}] FATAL ERROR: {VARIABLES_FILE} not found.")
-            return    
-
 
     # --- COMMAND: /editrole ---
 

--- a/cogs/rquote.py
+++ b/cogs/rquote.py
@@ -9,18 +9,14 @@ from discord import app_commands
 from discord import app_commands, AllowedMentions
 from datetime import datetime, timezone, timedelta
 import random
-import json
 import re
 import logging
+from config_loader import SETTINGS_DATA, MISC_DATA
 
 logger = logging.getLogger('discord')
 logger.setLevel(logging.INFO)
 
 GUILD_ID = int(os.getenv('guild'))
-
-VARIABLES_FILE = "data/variables.json"
-MISC_FILE = "data/misc_text.json"
-
 
 def custom_cooldown(interaction: discord.Interaction) -> app_commands.Cooldown | None:
 
@@ -36,7 +32,11 @@ def custom_cooldown(interaction: discord.Interaction) -> app_commands.Cooldown |
 class rquote(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.variables_file = {}
+        self.settings_data = SETTINGS_DATA
+        self.exempt_role_ids = set(SETTINGS_DATA["cooldown_exempt_roles"])
+        self.cooldown = SETTINGS_DATA["rquote_cooldown_in_minutes"]
+        self.themes = SETTINGS_DATA["rquote_themes"]
+        self.misc_data = MISC_DATA
     
         self.default_allowed_mentions = AllowedMentions(
                 everyone=False,
@@ -44,27 +44,6 @@ class rquote(commands.Cog):
                 roles=True      
             )
         
-        try:
-            with open(VARIABLES_FILE, 'r', encoding='utf-8') as file_object:
-                self.settings_data = json.load(file_object)
-                self.exempt_role_ids = set(self.settings_data.get("cooldown_exempt_roles"))
-                self.cooldown = self.settings_data.get("rquote_cooldown_in_minutes")
-                self.themes = self.settings_data["rquote_themes"]
-                logger.info(f"[{self.__class__.__name__}] Successfully loaded settings from {VARIABLES_FILE}")
-        
-        except FileNotFoundError:
-            logger.critical(f"[{self.__class__.__name__}] FATAL ERROR: {VARIABLES_FILE} not found.")
-            return
-        
-        try:
-            with open(MISC_FILE, 'r') as file_object:
-                self.misc_data = json.load(file_object)
-                logger.info(f"[{self.__class__.__name__}] Successfully loaded miscellaneous text from {MISC_FILE}")
-        
-        except FileNotFoundError:
-            logger.critical(f"[{self.__class__.__name__}] FATAL ERROR: {MISC_FILE} not found.")
-            return
-
 
     # --- COMMAND: /rquote ---
 

--- a/cogs/user_cmds.py
+++ b/cogs/user_cmds.py
@@ -7,37 +7,26 @@ import discord
 from discord.ext import commands
 from discord import app_commands
 from discord import app_commands, AllowedMentions
-import random
 import json
-import re
 import logging
+from config_loader import SETTINGS_DATA
 
 logger = logging.getLogger('discord')
 logger.setLevel(logging.INFO)
 
 GUILD_ID = int(os.getenv('guild'))
 
-VARIABLES_FILE = "data/variables.json"
-
 class user_cmds(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.variables_file = {}
+        self.settings_data = SETTINGS_DATA
     
         self.default_allowed_mentions = AllowedMentions(
                 everyone=False,
                 users=True, 
                 roles=True      
             )
-
-        try:
-            with open(VARIABLES_FILE, 'r', encoding='utf-8') as file_object:
-                self.settings_data = json.load(file_object)
-                logger.info(f"[{self.__class__.__name__}] Successfully loaded settings from {VARIABLES_FILE}")
-        
-        except FileNotFoundError:
-            logger.critical(f"[{self.__class__.__name__}] FATAL ERROR: {VARIABLES_FILE} not found.")
-            return
 
 
     # --- COMMAND: /info ---

--- a/config_loader.py
+++ b/config_loader.py
@@ -1,0 +1,22 @@
+import json
+import logging
+
+logger = logging.getLogger('discord')
+logger.setLevel(logging.INFO)
+
+VARIABLES_FILE = 'data/variables.json'
+MISC_FILE = 'data/misc_text.json'
+
+try:
+    with open(VARIABLES_FILE, 'r', encoding='utf-8') as file_object:
+        SETTINGS_DATA = json.load(file_object)
+
+except FileNotFoundError:
+    logger.critical(f"[FATAL ERROR: {VARIABLES_FILE} not found.")
+
+try:
+    with open(MISC_FILE, 'r', encoding='utf-8') as file_object:
+        MISC_DATA = json.load(file_object)
+
+except FileNotFoundError:
+    logger.critical(f"FATAL ERROR: {MISC_FILE} not found.")

--- a/data/variables_example.json
+++ b/data/variables_example.json
@@ -23,6 +23,8 @@
     },
     "edc_ip": "192.168.1.100",
     "rquote_cooldown_in_minutes": 1800,
+    "bibleq_hour_of_day": 1,
+    "bibleq_min_of_day": 0,
     "edc_ports": {
         "Dummy Game Alpha": 1234,
         "Dummy Game Beta": 5678,


### PR DESCRIPTION
The loading of JSON configuration has been centralized to a new `config_loader.py` file that is imported into the cogs. As part of this revamp various `imports` seen as unused by my IDE of choice were also cleaned.

As a direct result of this PR, the hour and minute when EnduraBot should send the bible quote has become configurable via `variables.json` with `variables_example.json` updated to reflect the expected variables.

Closes #53 and #37