### PR TITLE
Fix usage of rquote in OOC triggering cooldown

### DIFF
--- a/cogs/rquote.py
+++ b/cogs/rquote.py
@@ -27,6 +27,9 @@ def custom_cooldown(interaction: discord.Interaction) -> app_commands.Cooldown |
     if not cog_instance.exempt_role_ids.isdisjoint(user_role_ids):
         return None
     
+    if interaction.channel_id == SETTINGS_DATA["out_of_context_channel_id"]:
+        return None
+    
     return app_commands.Cooldown(1, cog_instance.cooldown)
 
 class rquote(commands.Cog):


### PR DESCRIPTION
Per #28 , prior to this PR, if a member attempted to generate a quote in `#out-of-context` they would get slammed with the cooldown despite a quote not being generated. This PR resolves this.

Closes #28 