### PR TITLE
Full logging suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
 *.env
+*.log
 data/variables.json
 data/misc_text.json

--- a/cogs/bible_daily.py
+++ b/cogs/bible_daily.py
@@ -6,8 +6,7 @@ import random
 import re
 from config_loader import SETTINGS_DATA, MISC_DATA
 
-logger = logging.getLogger('discord')
-logger.setLevel(logging.INFO)
+logger = logging.getLogger('endurabot.' + __name__)
 
 class bible_daily(commands.Cog):
     def __init__(self, bot):
@@ -48,6 +47,7 @@ class bible_daily(commands.Cog):
         # If a situation were to ever somehow occur where msg_table comes empty, use a pre-selected message to keep things moving.
         if not msg_table:
             selected_msg = await ooc_channel.fetch_message(1426039544490229811)
+            logger.error("msg_table interpreted as empty. Fallback message engaged.")
         else:       
             selected_msg = random.choice(msg_table)
 
@@ -67,6 +67,8 @@ class bible_daily(commands.Cog):
             embed.set_image(url=selected_msg.attachments[0].url)
 
         await based_chat_channel.send(content=f"# ✝️ Bible Quote of the Day\n\n:palms_up_together: {random_opener}", embed=embed)
+        logger.info("Daily bible quote sent.")
+        logger.debug(f"Daily bible quote sent. Channel: [#{based_chat_channel.name} ({based_chat_channel.id})]. Dated: [{selected_msg.created_at.strftime("%B %d, %Y")}]. Opener: [{random_opener}]. Gospel: [{random_gospel}]. Content: [{formatted_quote}].")
 
     @daily_bible_quote.before_loop
     async def before_daily_bible_quote(self):

--- a/cogs/bot_react.py
+++ b/cogs/bot_react.py
@@ -4,8 +4,7 @@ from discord import AllowedMentions
 import logging
 from config_loader import SETTINGS_DATA, MISC_DATA
 
-logger = logging.getLogger('discord')
-logger.setLevel(logging.DEBUG)
+logger = logging.getLogger('endurabot.' + __name__)
 
 class bot_react(commands.Cog):
     def __init__(self, bot):
@@ -42,6 +41,7 @@ class bot_react(commands.Cog):
                 description="An **automated filter** has detected that a recent ping was made to systems operators in relation to an issue with EDC services.\n\n The preferred method of reporting a service being down is `/alert`.",
                 color=8650752
             )
+            logger.info(f"{message.author.name} ({message.author.id}) triggered the /alert filter. Content: [{message.content}]")
             await message.channel.send(embed=embed)
         else:
             return

--- a/cogs/manage_role.py
+++ b/cogs/manage_role.py
@@ -9,9 +9,9 @@ from discord import app_commands
 from discord import app_commands, AllowedMentions
 import logging
 from config_loader import SETTINGS_DATA
+from logging_setup import UNAUTHORIZED
 
-logger = logging.getLogger('discord')
-logger.setLevel(logging.INFO)
+logger = logging.getLogger('endurabot.' + __name__)
 
 GUILD_ID = int(os.getenv('guild'))
 
@@ -39,11 +39,13 @@ class manage_role(commands.Cog):
         # If not a moderator or administrator, reject.
         if not guild_mod_role in interaction.user.roles and not guild_admin_role in interaction.user.roles:
             await interaction.response.send_message("Access denied.", ephemeral=True)
+            logger.log(UNAUTHORIZED, f"{interaction.user.name} ({interaction.user.id}) attempted to edit @{role.name} ({role.id}) for {user.name} ({user.id}).")
             return
 
         # If the role is not editable, reject.
         if role.id not in self.settings_data.get("mod_editable_roles").values():
             await interaction.response.send_message(f"{role.mention} is not on the approved list of editable roles.", ephemeral=True)
+            logger.log(UNAUTHORIZED, f"Staff member {interaction.user.name} ({interaction.user.id}) attempted to manipulate non-editable role @{role.name} ({role.id}) for {user.name} ({user.id}).")
             return
 
         # Change roles.
@@ -58,8 +60,10 @@ class manage_role(commands.Cog):
             
             if ping == True:    
                 await interaction.response.send_message(embed=embed, content=f"{user.mention}", allowed_mentions=self.default_allowed_mentions)
+                logger.info(f"{interaction.user.name} ({interaction.user.id}) removed @{role.name} ({role.id}) from {user.name} ({user.id}). Ping: [TRUE]")
             else:
                 await interaction.response.send_message(embed=embed)
+                logger.info(f"{interaction.user.name} ({interaction.user.id}) removed @{role.name} ({role.id}) from {user.name} ({user.id}). Ping: [FALSE]")
 
         else:
 
@@ -72,8 +76,10 @@ class manage_role(commands.Cog):
             
             if ping == True:    
                 await interaction.response.send_message(embed=embed, content=f"{user.mention}", allowed_mentions=self.default_allowed_mentions)
+                logger.info(f"{interaction.user.name} ({interaction.user.id}) added @{role.name} ({role.id}) to {user.name} ({user.id}). Ping: [TRUE]")
             else:
                 await interaction.response.send_message(embed=embed)
+                logger.info(f"{interaction.user.name} ({interaction.user.id}) added @{role.name} ({role.id}) to {user.name} ({user.id}). Ping: [FALSE]")
         
 async def setup(bot):
     await bot.add_cog(manage_role(bot))

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -1,0 +1,72 @@
+import logging
+import sys
+import datetime
+
+# Custom logging levels
+UNAUTHORIZED = 35
+logging.addLevelName(UNAUTHORIZED, 'UNAUTHORIZED')
+
+COOLDOWN = 25
+logging.addLevelName(COOLDOWN, 'COOLDOWN')
+
+BOOT = 26
+logging.addLevelName(BOOT, 'BOOT')
+
+
+# Custom filter so that debug messages go to their own file.
+class DebugOnlyFilter(logging.Filter):
+    def filter(self, record):
+        return record.levelno == logging.DEBUG
+
+
+# Custom formatting for BOOT
+class CustomBootFormatter(logging.Formatter):
+    def __init__(self, fmt=None, datefmt=None, style='%'):
+        super().__init__(fmt, datefmt, style)
+        self.default_formatter = logging.Formatter(fmt, datefmt, style)
+        self.boot_formatter = logging.Formatter('%(message)s', datefmt=None, style=style)
+
+    def format(self, record):
+        if record.levelno == BOOT:
+            return self.boot_formatter.format(record)
+        else:
+            return self.default_formatter.format(record)
+
+# Rest of logging configuration as a function that can be called in main.py
+def configure_logging():
+    logger = logging.getLogger('endurabot')
+    logger.setLevel(logging.DEBUG)
+
+    discord_logger = logging.getLogger('discord')
+    discord_logger.setLevel(logging.INFO) 
+
+    standard_formatter = CustomBootFormatter( 
+        fmt='[%(asctime)s]:%(levelname)s:%(name)s: %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    ) 
+
+    file_handler = logging.FileHandler(filename="logs/endurabot.log", encoding='utf-8', mode='a')
+    file_handler.setLevel(logging.INFO)
+    file_handler.setFormatter(standard_formatter)
+    logger.addHandler(file_handler)
+    discord_logger.addHandler(file_handler)   
+
+
+    file_handler_debug = logging.FileHandler(filename="logs/endurabot_debug.log", encoding='utf-8', mode='a')
+    file_handler_debug.setLevel(logging.DEBUG)
+    file_handler_debug.setFormatter(standard_formatter)
+    file_handler_debug.addFilter(DebugOnlyFilter()) # Apply the debug-only filter
+    logger.addHandler(file_handler_debug)
+    discord_logger.addHandler(file_handler_debug)
+
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(logging.DEBUG)
+    console_handler.setFormatter(standard_formatter)
+    logger.addHandler(console_handler)
+    discord_logger.addHandler(console_handler)
+    
+    now = datetime.datetime.now()
+    boot_message = f"--- {now.strftime('%A, %B %d, %Y (%Y%m%d)')} | {now.strftime('%H:%M')} ---"
+    logger.log(BOOT, boot_message)
+
+    return logger

--- a/main.py
+++ b/main.py
@@ -1,21 +1,24 @@
 import os
 from dotenv import load_dotenv
-import logging
+from datetime import datetime
 
 load_dotenv()
-
-logger = logging.getLogger('discord')
-logger.setLevel(logging.DEBUG)
 
 import discord
 from discord.ext import commands
 
+# Setup logging
+import logging_setup
+logger = logging_setup.configure_logging()
+
+# Environment variable stuff
 BOT_TOKEN= os.getenv('bot_token')
 GUILD_ID = int(os.getenv('guild'))
 
 guild_object = discord.Object(id=GUILD_ID)
 whitelisted_guild_ids_str = os.getenv('guilds')
 
+# Intents
 intents = discord.Intents.default()
 intents.members = True         
 intents.presences = True        
@@ -50,6 +53,8 @@ async def on_ready():
         logger.info(f"Synced {len(synced)} commands.")
     except Exception as e:
         logger.critical("FATAL ERROR: ", e)    
+
+    logger.info("Hello, world! I am awake and ready to work!")
 
 bot.run(BOT_TOKEN)
 


### PR DESCRIPTION
Alright. This is a doozy.

- _All_ bot actions now log using Python's `logging` library.
- Logged actions are to files in folder `log`. It is not included in this repository for practical reasons; making an example log file is not useful as running the bot automates their creation.
- In line with the above, `.log` files added to `.gitignore` as that extension will be used for generated log files.
- All logging setup consolidated into new file `logging_setup.py`.
- 3 custom logging levels: `UNAUTHORIZED`, `COOLDOWN`, and `BOOT` are created.
     - `UNAUTHORIZED` for events where a member attempts to do something and is intentionally stopped.
     - `COOLDOWN` for when a member hits the `/rquote` cooldown.
     - `BOOT` for special formatting so that the file the logs go to separate the bot booting up with the date and time for easier reading.
- In `rquote.py` a local variable `has_attachment` is created so that the debug variant of a quote being generated can declare if the chosen message had an attachment or not.