### PR TITLE
Fix /estop and make /data/ and /logs/ volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY main.py .
+COPY .env .
+COPY logging_setup.py .
+COPY config_loader.py .
+COPY cogs/ cogs/
 
 CMD ["python", "main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,7 @@ services:
     # Give a human-readable name to the running container
     container_name: EnduraBot
     # Automatically restart the container if it stops, unless explicitly told to stop
-    restart: unless-stopped
+    restart: on-failure
+    volumes:
+    - /home/sirdog/endurabot-dev/data:/app/data
+    - /home/sirdog/endurabot-dev/logs:/app/logs


### PR DESCRIPTION
`/estop` now functions as the `docker-compose.yml` instructions for when a container should restart has changed from `unless-stopped` to `on-failure`. Usage of `/estop` is a graceful shutdown which the Docker container now respects.

Host machine directories `/data/` and `/logs/` have been turned into Docker volumes, allowing their viewing and manipulation while the container is active.

Closes #54 and #51 