### PR TITLE
Make auto pass admin, not owner

### DIFF
--- a/permissions_checker.py
+++ b/permissions_checker.py
@@ -23,8 +23,8 @@ async def check_permissions(interaction: discord.Interaction):
 
     if set(eligible_roles_objects).intersection(user_roles):
         return True
-    elif not set(eligible_roles_objects).intersection(user_roles) and interaction.user == interaction.guild.owner:
-        logger.debug(f"Owner {interaction.user.name} ({interaction.user.id}) bypassed traditional restrictions for command /{interaction.command.name}.")
+    elif not set(eligible_roles_objects).intersection(user_roles) and interaction.user.guild_permissions.administrator:
+        logger.debug(f"Administrator {interaction.user.name} ({interaction.user.id}) bypassed traditional restrictions for command /{interaction.command.name}.")
         return True
     else:
         return False


### PR DESCRIPTION
Any user with the `Administrator` permission will now pass all permissions checks, not just the guild owner.

Closes #78 