### PR TITLE
Fix cmd func name, add debug lines to insults

### DIFF
--- a/cogs/user_cmds.py
+++ b/cogs/user_cmds.py
@@ -208,7 +208,7 @@ class user_cmds(commands.Cog):
     @app_commands.command(name="reboot", description="Reboot EnduraBot.")
     @app_commands.check(check_permissions)
     @app_commands.guilds(GUILD_ID)
-    async def rconfig(self, interaction: discord.Interaction):
+    async def reboot(self, interaction: discord.Interaction):
 
         logger.critical(f"{interaction.user.name} ({interaction.user.id}) rebooted me.")
         await interaction.response.send_message("Rebooting...", ephemeral=True)

--- a/listeners/bot_insult.py
+++ b/listeners/bot_insult.py
@@ -30,8 +30,10 @@ class bot_insult(commands.Cog):
 
             if value <= chance:
                 random_insult = random.choice(MISC_DATA["bot_insults"])
+                logger.debug(f"{message.author.name} ({message.author.id}) pinged EnduraBot and triggered an insult at value [{value}]. Insult was [{random_insult}].")
                 await message.channel.send(f"{message.author.mention}, {random_insult}", allowed_mentions=self.default_allowed_mentions)
             else:
+                logger.debug(f"{message.author.name} ({message.author.id}) pinged EnduraBot and did NOT trigger an insult at value [{value}].")
                 return 
 
 async def setup(bot):


### PR DESCRIPTION
Resolves #83 

- Made the function name for `/reboot` match the command as I failed to adjust it in #71 
- Add debug lines for when EnduraBot determines if insults should happen for monitoring purposes