### PR TITLE
Remove hardcoded URL, update example JSON files, remove redundant variables

### DIFF
--- a/cogs/user_cmds.py
+++ b/cogs/user_cmds.py
@@ -184,10 +184,11 @@ class user_cmds(commands.Cog):
 
         ports_list = self.settings_data.get("edc_ports", {})
         edc_ip = self.settings_data.get("edc_ip")
+        edc_url = self.settings_data.get("edc_url")
 
         embed = discord.Embed(
             title="Endurance Coalition IP Addresses",
-            description=f"Most games should accept `edcgaming.org` as our IP address. Just append the port to the end like usual.\n\n If for some reason that does not work, our *raw* IP is `{edc_ip}`.",
+            description=f"Most games should accept `{edc_url}` as our IP address. Just append the port to the end like usual.\n\n If for some reason that does not work, our *raw* IP is `{edc_ip}`.",
             color=discord.Color.blue()
         )
 

--- a/data/variables_example.json
+++ b/data/variables_example.json
@@ -7,9 +7,7 @@
     "sysop_role_id": 3456789012345678901,
     "mod_role_id": 4567890123456789012,
     "admin_role_id": 5678901234567890123,
-    "roach_cock_role_id": 6789012345678901234,
     "L_role_id": 7890123456789012345,
-    "sailor_role_id": 8901234567890123456,
     "cooldown_exempt_roles": [
         9012345678901234567,
         1023456789012345678
@@ -22,6 +20,7 @@
         "https://github.com/dummyuser/dummyrepo": "DummyBot GitHub Source"
     },
     "edc_ip": "192.168.1.100",
+    "edc_url": "google.com",
     "rquote_cooldown_in_minutes": 1800,
     "bot_insult_chance": 1,
     "bibleq_hour_of_day": 1,


### PR DESCRIPTION
Resolves #86 and #87 

- Switched out hardcoded `edcgaming.org` URL in `/ips` with a new variable in `variables.json` called `edc_url`.
- Redundant variables `roach_cock_role_id` and `sailor_role_id` removed.