### PR TITLE
New command: /takel

### DIFF
--- a/classes/db_takeL_handler.py
+++ b/classes/db_takeL_handler.py
@@ -1,0 +1,97 @@
+import sqlite3
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import logging
+import datetime
+from datetime import datetime
+
+logger = logging.getLogger("endurabot." + __name__)
+
+
+class DBTakeL:
+    def __init__(self):
+        self.connection = sqlite3.connect("endurabot.db")
+        self.cursor = self.connection.cursor()
+        check_if_table_exists = """CREATE TABLE IF NOT EXISTS users_with_l(users_with_l_id INTEGER PRIMARY KEY AUTOINCREMENT, users_with_l_name TEXT, users_with_l_disc_id NUMERIC,
+        users_with_l_mod_name TEXT, users_with_l_mod_disc_id NUMERIC, users_with_l_timestamp NUMERIC)"""
+        self.cursor.execute(check_if_table_exists)
+        self.connection.commit()
+
+    def check_status(self, target_id):
+
+        self.cursor.execute("SELECT users_with_l_disc_id FROM users_with_l")
+        tuple = self.cursor.fetchall()
+        list = [ints[0] for ints in tuple]
+
+        if target_id in list:
+            return True
+        else:
+            return False
+
+    def add_user(self, target_id, target_name, mod_id, mod_name, timestamp):
+        if self.check_status(target_id) == True:
+            self.remove_user_by_id(target_id)
+
+        self.cursor.execute(
+            f"INSERT INTO users_with_l(users_with_l_disc_id, users_with_l_name, users_with_l_mod_disc_id, users_with_l_mod_name, users_with_l_timestamp) VALUES (?, ?, ?, ?, ?)",
+            (target_id, target_name, mod_id, mod_name, timestamp),
+        )
+        self.connection.commit()
+
+    def remove_user_by_timestamp(self, timestamp):
+        self.cursor.execute(
+            f"DELETE FROM users_with_l WHERE users_with_l_timestamp = ?", (timestamp,)
+        )
+        self.connection.commit()
+
+    def remove_user_by_id(self, target_id):
+        self.cursor.execute(
+            f"DELETE FROM users_with_l WHERE users_with_l_disc_id = ?", (target_id,)
+        )
+        self.connection.commit()
+
+    def get_user_id_by_timestamp(self, timestamp):
+
+        self.cursor.execute(f"SELECT users_with_l_disc_id FROM users_with_l WHERE users_with_l_timestamp = ?", (timestamp,))
+        result = self.cursor.fetchone()
+        return result[0]
+
+    def get_user_name_by_timestamp(self, timestamp):
+
+        self.cursor.execute(f"SELECT users_with_l_name FROM users_with_l WHERE users_with_l_timestamp = ?", (timestamp,))
+        result = self.cursor.fetchone()
+        return result[0]
+
+    def get_mod(self, target_id):
+        if self.check_status(target_id) == False:
+            raise ValueError("User does not have the L.")
+
+        self.cursor.execute(f"SELECT users_with_l_mod_disc_id FROM users_with_l WHERE users_with_l_disc_id = ?", (target_id,))
+        result = self.cursor.fetchone()
+
+        return result[0]
+
+    def check_time(self, target_id):
+        if self.check_status(target_id) == False:
+            raise ValueError("User does not have the L.")
+
+        self.cursor.execute(f"SELECT users_with_l_timestamp FROM users_with_l WHERE users_with_l_disc_id = ?", (target_id,))
+        result = self.cursor.fetchone()
+
+        timestamp_str = result[0]
+
+        dt_object = datetime.strptime(timestamp_str, "%Y-%m-%d %H:%M:%S")
+
+        epoch = round(dt_object.timestamp())
+
+        return epoch
+
+    def get_timestamps(self):
+        self.cursor.execute("SELECT users_with_l_timestamp FROM users_with_l")
+        timestamps = [datetime.strptime(id[0], "%Y-%m-%d %H:%M:%S") for id in self.cursor.execute("SELECT users_with_l_timestamp FROM users_with_l")]
+        return timestamps
+
+#db = DBTakeL()
+#print(db.get_user_by_timestamp("2025-11-05 21:22:05.642560"))

--- a/tasks/take_l_monitor.py
+++ b/tasks/take_l_monitor.py
@@ -1,0 +1,56 @@
+import os
+from discord.utils import get
+import datetime
+from datetime import datetime
+from discord.ext import tasks, commands
+import logging
+from classes.db_takeL_handler import DBTakeL
+from utils.config_loader import SETTINGS_DATA
+
+logger = logging.getLogger("endurabot." + __name__)
+
+take_l_db = DBTakeL()
+
+GUILD_ID = int(os.getenv("guild"))
+
+
+class take_l_monitor(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.guild = bot.get_guild(GUILD_ID)
+        self.settings_data = SETTINGS_DATA
+        self.check_length_minutely.start()
+
+    def cog_unload(self):
+        self.check_length_minutely.cancel()
+
+    @tasks.loop(minutes=1)
+    async def check_length_minutely(self):
+
+        timestamps = take_l_db.get_timestamps()
+
+        for timestamp in timestamps:
+            if datetime.now() > timestamp:
+                user = self.guild.get_member(
+                    take_l_db.get_user_id_by_timestamp(timestamp)
+                )
+                role = self.guild.get_role(self.settings_data.get("l_role_id"))
+                if role in user.roles:
+                    await user.remove_roles(role)
+                    logger.info(
+                        f"{take_l_db.get_user_name_by_timestamp(timestamp)} ({take_l_db.get_user_id_by_timestamp(timestamp)}) was given the L and it's duration has ended. Role removed and L-status removed from database."
+                    )
+                    take_l_db.remove_user_by_timestamp(timestamp)
+                else:
+                    logger.info(
+                        f"{take_l_db.get_user_name_by_timestamp(timestamp)} ({take_l_db.get_user_id_by_timestamp(timestamp)}) was given the L and it's duration has ended. Role detected to have been removed early. Removed L-status from database."
+                    )
+                    take_l_db.remove_user_by_timestamp(timestamp)
+
+    @check_length_minutely.before_loop
+    async def before_daily_bible_quote(self):
+        await self.bot.wait_until_ready()
+
+
+async def setup(bot):
+    await bot.add_cog(take_l_monitor(bot))


### PR DESCRIPTION
Add new `/takel` command. Allows giving a user `@L` for a specified duration in hours, defaulting to 1 day, and EnduraBot will automatically remove it once the duration expires.

- If the command is ran while a user already has an entry in the relevant DB table the old one is deleted and replaced with a new one.
- If the L is removed early, and the duration is reached, EnduraBot will handle it gracefully and still remove the DB entry.
- If the L is removed _and given back_, from EnduraBot's perspective, nothing has changed, and the role will be removed at the original time.
- Using the optional `check` parameter allows checking if a specific person has the L and, if so, who gave it, and when it's set to expire.

Closes #75 