### PR TITLE
Set new log header daily

### DIFF
--- a/data/variables_example.json
+++ b/data/variables_example.json
@@ -27,6 +27,7 @@
     "bot_insult_chance": 1,
     "bibleq_hour_of_day": 1,
     "bibleq_min_of_day": 0,
+    "log_new_day_hour_utc": 0,
     "edc_ports": {
         "Dummy Game Alpha": 1234,
         "Dummy Game Beta": 5678,

--- a/tasks/log_daily_reset.py
+++ b/tasks/log_daily_reset.py
@@ -1,0 +1,33 @@
+
+from datetime import time, timezone
+from discord.ext import tasks, commands
+import logging
+import datetime
+from utils.config_loader import SETTINGS_DATA
+from utils.logging_setup import BOOT
+
+logger = logging.getLogger('endurabot.' + __name__)
+
+class log_daily_reset(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.log_daily_reset_func.start()
+        self.settings_data = SETTINGS_DATA
+
+    def cog_unload(self):
+        self.log_daily_reset_func.cancel()
+
+    @tasks.loop(time=time(hour=SETTINGS_DATA["log_new_day_hour_utc"], minute=0, tzinfo=timezone.utc))
+    async def log_daily_reset_func(self):
+        await self.bot.wait_until_ready()
+
+        now = datetime.datetime.now()
+        boot_message = f"\n--- {now.strftime('%A, %B %d, %Y (%Y%m%d)')} | {now.strftime('%H:%M')} ---"
+        logger.log(BOOT, boot_message)
+    
+    @log_daily_reset_func.before_loop
+    async def before_daily_reset(self):
+        await self.bot.wait_until_ready()
+
+async def setup(bot):
+    await bot.add_cog(log_daily_reset(bot))


### PR DESCRIPTION
So, apparently, getting the bot to restart cleanly using a task loop _isn't_ an easy win. Ugh.

Alas, I instead looked in `utils/logging_setup.py` and saw I had an entire custom log level for the `BOOT` header. The whole point of restarting was just to ensure a new header exists per day at midnight. So, I instead had the loop just send another one of those at midnight every night.

_That_ was an easy win.

New variable created since daylight savings time changes the hour requirement. `variables_example.json` updated appropriately.

Closes #122 