### PR TITLE
Fix monitor datatype issues

### DIFF
--- a/classes/db_monitor_handler.py
+++ b/classes/db_monitor_handler.py
@@ -12,8 +12,8 @@ class DBMonitor():
     def __init__(self):
         self.connection = sqlite3.connect('endurabot.db')
         self.cursor = self.connection.cursor()
-        check_if_table_exists = """CREATE TABLE IF NOT EXISTS member_monitor(member_monitor_id INTEGER PRIMARY KEY AUTOINCREMENT, member_monitor_name TEXT, 
-        member_monitor_disc_id NUMERIC, member_monitor_steam_id TEXT, member_monitor_mod_name TEXT, member_monitor_mod_disc_id NUMERIC, 
+        check_if_table_exists = """CREATE TABLE IF NOT EXISTS member_monitor(member_monitor_id INTEGER PRIMARY KEY AUTOINCREMENT, member_monitor_name TEXT,
+        member_monitor_disc_id TEXT, member_monitor_steam_id TEXT, member_monitor_mod_name TEXT, member_monitor_mod_disc_id TEXT,
         member_monitor_reason TEXT, member_monitor_timestamp NUMERIC, member_monitor_level TEXT)"""
         self.cursor.execute(check_if_table_exists)
         self.connection.commit()
@@ -28,11 +28,11 @@ class DBMonitor():
             return True
         else:
             return False
-        
+
     def add_user(self, target_name, target_disc_id, target_steam_id, mod_name, mod_disc_id, reason, level):
         if self.check_status(target_disc_id) == True:
             raise ValueError("User already being monitored.")
-         
+
         timestamp = round(discord.utils.utcnow().timestamp())
         self.cursor.execute(f"INSERT INTO member_monitor(member_monitor_name, member_monitor_disc_id, member_monitor_steam_id, member_monitor_mod_name, member_monitor_mod_disc_id, member_monitor_reason, member_monitor_timestamp, member_monitor_level) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", (target_name, target_disc_id, target_steam_id, mod_name, mod_disc_id, reason, timestamp, level))
         self.connection.commit()
@@ -40,70 +40,69 @@ class DBMonitor():
     def remove_user(self, target_disc_id):
         if self.check_status(target_disc_id) == False:
             raise ValueError("User already not being monitored.")
-        
+
         self.cursor.execute(f"DELETE FROM member_monitor WHERE member_monitor_disc_id = ?", (target_disc_id,))
         self.connection.commit()
 
     def get_name(self, target_disc_id):
         if self.check_status(target_disc_id) == False:
             raise ValueError("User not found.")
-        
+
         self.cursor.execute(f"SELECT member_monitor_name FROM member_monitor WHERE member_monitor_disc_id = ?", (target_disc_id,))
         result = self.cursor.fetchone()
 
         return result[0]
-    
+
     def get_steamid(self, target_disc_id):
         if self.check_status(target_disc_id) == False:
             raise ValueError("User not found.")
-        
+
         self.cursor.execute(f"SELECT member_monitor_steam_id FROM member_monitor WHERE member_monitor_disc_id = ?", (target_disc_id,))
         result = self.cursor.fetchone()
 
         return result[0]
-    
+
     def get_mod_name(self, target_disc_id):
         if self.check_status(target_disc_id) == False:
             raise ValueError("User not found.")
-        
+
         self.cursor.execute(f"SELECT member_monitor_mod_name FROM member_monitor WHERE member_monitor_disc_id = ?", (target_disc_id,))
         result = self.cursor.fetchone()
 
         return result[0]
-    
+
     def get_mod_id(self, target_disc_id):
         if self.check_status(target_disc_id) == False:
             raise ValueError("User not found.")
-        
+
         self.cursor.execute(f"SELECT member_monitor_mod_disc_id FROM member_monitor WHERE member_monitor_disc_id = ?", (target_disc_id,))
         result = self.cursor.fetchone()
 
         return result[0]
-    
+
     def get_reason(self, target_disc_id):
         if self.check_status(target_disc_id) == False:
             raise ValueError("User not found.")
-        
+
         self.cursor.execute(f"SELECT member_monitor_reason FROM member_monitor WHERE member_monitor_disc_id = ?", (target_disc_id,))
         result = self.cursor.fetchone()
 
         return result[0]
-    
+
     def get_timestamp(self, target_disc_id):
         if self.check_status(target_disc_id) == False:
             raise ValueError("User not found.")
-        
+
         self.cursor.execute(f"SELECT member_monitor_timestamp FROM member_monitor WHERE member_monitor_disc_id = ?", (target_disc_id,))
         result = self.cursor.fetchone()
 
         return result[0]
-    
+
     def get_level(self, target_disc_id):
         if self.check_status(target_disc_id) == False:
             raise ValueError("User not found.")
-        
+
         self.cursor.execute(f"SELECT member_monitor_level FROM member_monitor WHERE member_monitor_disc_id = ?", (target_disc_id,))
         result = self.cursor.fetchone()
 
         return result[0]
-    

--- a/cogs/user_cmds.py
+++ b/cogs/user_cmds.py
@@ -171,7 +171,7 @@ class user_cmds(commands.Cog):
 ])
     @app_commands.describe(
         options = "What information do you want?"
-    )   
+    )
     async def info(self, interaction: discord.Interaction, options: app_commands.Choice[str]):
 
         if options.value == "links":
@@ -249,7 +249,7 @@ class user_cmds(commands.Cog):
         target = "Who gets the L?",
         length = "Length, in hours, the L should last for. (default: 24)",
         check = "If true, will be told if there's an active timer for the target. Nothing else will happen."
-    )  
+    )
     async def takel(self, interaction: discord.Interaction, target: discord.Member, length: int = 24, check: bool = False):
 
         guild_l_role = discord.utils.get(interaction.guild.roles, id=self.settings_data.get("l_role_id"))
@@ -271,7 +271,7 @@ class user_cmds(commands.Cog):
                 return
 
         if target.bot:
-            await interaction.response.send_message("Bots may not be given the L.", ephemeral=True) 
+            await interaction.response.send_message("Bots may not be given the L.", ephemeral=True)
             logger.log(UNAUTHORIZED, f"{interaction.user.name} ({interaction.user.id}) tried to give the L to bot {target.name} ({target.id}).")
             return
 
@@ -334,25 +334,25 @@ class user_cmds(commands.Cog):
 
         if action.value == "add":
 
-            if monitor_db.check_status(int(disc_id)) == True:
+            if monitor_db.check_status(disc_id) == True:
                 await interaction.response.send_message("Discord ID is already being monitored.", ephemeral=True)
-                logger.error(f"{interaction.user.name} ({interaction.user.id}) attempted to add {monitor_db.get_name(int(disc_id))} ({disc_id}) when they are already being monitored.")
+                logger.error(f"{interaction.user.name} ({interaction.user.id}) attempted to add {monitor_db.get_name(disc_id)} ({disc_id}) when they are already being monitored.")
                 return
-            
+
             monitor_db.add_user(target_disc_id=disc_id, target_name=name, target_steam_id=steam_id, mod_name=f"{interaction.user.name}", mod_disc_id=f"{interaction.user.id}", reason=reason, level=level.value)
             await interaction.response.send_message("Entry successfully added.", ephemeral=True)
             logger.info(f"{interaction.user.name} ({interaction.user.id}) added {name} (Discord: {disc_id} | Steam: {steam_id}) for monitoring at level [{level.value.upper()}]. Reason: [{reason}]")
             return
-        
+
         if action.value == "remove":
-            if monitor_db.check_status(int(disc_id)) == False:
+            if monitor_db.check_status(disc_id) == False:
                 await interaction.response.send_message("Discord ID is already not being monitored.", ephemeral=True)
                 logger.error(f"{interaction.user.name} ({interaction.user.id}) attempted to remove {disc_id} from monitoring but the ID wasn't found.")
                 return
-            
+
             await interaction.response.send_message("Entry successfully removed.", ephemeral=True)
-            logger.info(f"{interaction.user.name} ({interaction.user.id}) removed {monitor_db.get_name(int(disc_id))} ({disc_id}) from monitoring.")
-            monitor_db.remove_user(int(disc_id))
+            logger.info(f"{interaction.user.name} ({interaction.user.id}) removed {monitor_db.get_name(disc_id)} ({disc_id}) from monitoring.")
+            monitor_db.remove_user(disc_id)
             return
 
 async def setup(bot):


### PR DESCRIPTION
I accidentally set the `disc_id` columns to use the `NUMERIC` SQLITE datatype. This isn't kosher, as that datatype seems to automatically round to the next 10th, which would obviously make checks not function.

This ensures relevant columns are `TEXT` and removes code that forces `INT` types into those columns.