### PR TITLE
Mitigate /rquote duplicate selections

### DIFF
--- a/classes/db_rquote_used_handler.py
+++ b/classes/db_rquote_used_handler.py
@@ -1,0 +1,46 @@
+import sqlite3
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import logging
+from utils.config_loader import SETTINGS_DATA
+
+logger = logging.getLogger("endurabot." + __name__)
+
+class RquoteUsed:
+    def __init__(self):
+        self.connection = sqlite3.connect("endurabot.db")
+        self.cursor = self.connection.cursor()
+        check_if_table_exists = """CREATE TABLE IF NOT EXISTS rquote_used(rquote_used_id INTEGER PRIMARY KEY AUTOINCREMENT, rquote_used_msg_id TEXT)"""
+        self.cursor.execute(check_if_table_exists)
+        self.connection.commit()
+
+    def check_status(self, msg_id):
+        self.cursor.execute("SELECT rquote_used_msg_id FROM rquote_used")
+        tuple = self.cursor.fetchall()
+        list = [ints[0] for ints in tuple]
+
+        if msg_id in list:
+            return True
+        else:
+            return False
+        
+    def get_row_count(self):
+        self.cursor.execute("SELECT Count(*) FROM rquote_used")
+        count = self.cursor.fetchone()
+        return count[0]
+    
+    def delete_oldest_row(self):
+        self.cursor.execute("DELETE FROM rquote_used WHERE rowid=(SELECT MIN(rquote_used_id) FROM rquote_used)")
+        self.connection.commit()
+
+    def add_msg(self, msg_id):
+        if self.check_status(msg_id) == True:
+            raise ValueError("Message already in table.")
+        
+        if self.get_row_count() >= SETTINGS_DATA["max_old_quotes"]:
+            self.delete_oldest_row()
+
+        self.cursor.execute(f"INSERT INTO rquote_used(rquote_used_msg_id) VALUES (?)", (msg_id,))
+        self.connection.commit()

--- a/cogs/rquote.py
+++ b/cogs/rquote.py
@@ -14,6 +14,9 @@ import logging
 from utils.config_loader import SETTINGS_DATA, MISC_DATA
 from utils.logging_setup import COOLDOWN, UNAUTHORIZED
 from utils.permissions_checker import check_permissions
+from classes.db_rquote_used_handler import RquoteUsed
+
+dupe_blocker = RquoteUsed()
 
 logger = logging.getLogger('endurabot.' + __name__)
 
@@ -83,9 +86,14 @@ class rquote(commands.Cog):
                     re.search(r'''["](.+?)["]''', msg.content)
                 ))
             )
+            and (
+                dupe_blocker.check_status(f"{msg.id}") == False
+            )
         ]
 
         selected_msg = random.choice(msg_table)
+
+        dupe_blocker.add_msg(f"{selected_msg.id}")
 
         all_matches = re.findall(r'''["](.+?)["]''', selected_msg.content)
         extracted_quote = '"\n"'.join(match.strip() for match in all_matches)

--- a/data/variables_example.json
+++ b/data/variables_example.json
@@ -23,6 +23,7 @@
     "edc_ip": "192.168.1.100",
     "edc_url": "google.com",
     "rquote_cooldown_in_minutes": 1800,
+    "max_old_quotes": 300,
     "bot_insult_chance": 1,
     "bibleq_hour_of_day": 1,
     "bibleq_min_of_day": 0,


### PR DESCRIPTION
So. Mitigation works like this:

- The table of available quotes has a new filter to see if the message is in the `rquote_used` table. If it is, it doesn't get added to the list of messages that can be selected.
- Once a message is selected, _that_ message _does_ get added to the table.
- Once the total number of messages in the table meets or exceeds a configurable value, the oldest message on the table is automatically removed from the table, allowing it to be selected again in the future.

With a high enough configurable value it will functionally be as if duplication does not happen.

Closes #137 