### PR TITLE
Allow early /trole removal

### DIFF
--- a/classes/db_trole_handler.py
+++ b/classes/db_trole_handler.py
@@ -31,8 +31,8 @@ class DBTempRole:
             return False
 
     def add_user(self, target_id, target_name, mod_id, mod_name, role_id, timestamp):
-        if self.check_status(target_id) == True:
-            self.remove_user_by_id(target_id)
+        if self.check_status(str(target_id)) == True:
+            self.remove_user_by_id(str(target_id))
 
         self.cursor.execute(
             f"INSERT INTO temp_roles(temp_roles_disc_id, temp_roles_name, temp_roles_mod_disc_id, temp_roles_mod_name, temp_roles_role_id, temp_roles_timestamp) VALUES (?, ?, ?, ?, ?, ?)",

--- a/tasks/temp_role_monitor.py
+++ b/tasks/temp_role_monitor.py
@@ -38,12 +38,12 @@ class take_l_monitor(commands.Cog):
                 if role in user.roles:
                     await user.remove_roles(role)
                     logger.info(
-                        f"{temp_role.get_user_name_by_timestamp(timestamp)} ({temp_role.get_user_id_by_timestamp(timestamp)}) was given [{role.name}] temporarily and the duration has ended. Role removed and status removed from database."
+                        f"{temp_role.get_user_name_by_timestamp(timestamp)} ({temp_role.get_user_id_by_timestamp(timestamp)}) was given [@{role.name}] temporarily and the duration has ended. Role removed and status removed from database."
                     )
                     temp_role.remove_user_by_timestamp(timestamp)
                 else:
                     logger.info(
-                        f"{temp_role.get_user_name_by_timestamp(timestamp)} ({temp_role.get_user_id_by_timestamp(timestamp)}) was given [{role.name}] temporarily and the duration has ended. Role detected to have been removed early. Removed status from database."
+                        f"{temp_role.get_user_name_by_timestamp(timestamp)} ({temp_role.get_user_id_by_timestamp(timestamp)}) was given [@{role.name}] temporarily and the duration has ended. Role detected to have been removed early. Removed status from database."
                     )
                     temp_role.remove_user_by_timestamp(timestamp)
 


### PR DESCRIPTION
Added argument `remove` to command `/trole` which allows the early removal of a temporary role assignment. 

There was also a lot of refactoring done to:
- Ensure `check` and `remove` function correctly
- Properly log the roles being changed
- That the command behaves as expected if running the command on a user who already has a temporary role DB entry

Closes #150 