### PR TITLE
Rename variable to reflect reality

### DIFF
--- a/cogs/rquote.py
+++ b/cogs/rquote.py
@@ -41,7 +41,7 @@ class rquote(commands.Cog):
         self.bot = bot
         self.settings_data = SETTINGS_DATA
         self.exempt_role_ids = set(SETTINGS_DATA["cooldown_exempt_roles"])
-        self.cooldown = SETTINGS_DATA["rquote_cooldown_in_minutes"]
+        self.cooldown = SETTINGS_DATA["rquote_cooldown_in_seconds"]
         self.themes = SETTINGS_DATA["rquote_themes"]
         self.misc_data = MISC_DATA
     

--- a/data/variables_example.json
+++ b/data/variables_example.json
@@ -22,7 +22,8 @@
     },
     "edc_ip": "192.168.1.100",
     "edc_url": "google.com",
-    "rquote_cooldown_in_minutes": 1800,
+    "rquote_cooldown_in_seconds": 1800,
+    "game_cooldown_in_seconds": 600,
     "max_old_quotes": 300,
     "bot_insult_chance": 1,
     "bibleq_hour_of_day": 1,
@@ -38,6 +39,9 @@
         "dummy_role_a": 1122334455667788990,
         "dummy_role_b": 2233445566778899001,
         "dummy_role_c": 3344556677889900112
+    },
+    "blacklisted_itad_shops": {
+        "Fanatical": 6
     },
     "rquote_themes": {
         "hr": {


### PR DESCRIPTION
Variable `rquote_cooldown_in_minutes` renamed to `rquote_cooldown_in_seconds` as the value must be an integer in seconds, not minutes, for a valid cooldown. Also updated `variables_example.json` to reflect new variables added in PR #165