### PR TITLE
Improved fuzzy searching on /game

### DIFF
--- a/classes/itad_get_games_handler.py
+++ b/classes/itad_get_games_handler.py
@@ -13,19 +13,19 @@ API_TOKEN = os.getenv('itad-token')
 class ItadGameSearchHandler():
     def __init__(self, title):
         
-        base_url_by_name = "https://api.isthereanydeal.com/games/lookup/v1"
+        base_url_by_name = "https://api.isthereanydeal.com/games/search/v1"
         base_name_payload = {'key': API_TOKEN, 'title': title}
         base_payload = requests.get(base_url_by_name, params=base_name_payload)
 
         if self.check_connection() == False:
             raise TypeError("API token missing or invalid.")
-
-        base_data = base_payload.json()
         
-        if base_data["found"] == False or base_data["game"]["type"] == None:
+        if not base_payload.json():
             raise ValueError("Game not found.")
 
-        game_id = base_data["game"]["id"]
+        base_data = base_payload.json()[0]
+
+        game_id = base_data["id"]
 
         full_url = "https://api.isthereanydeal.com/games/info/v2"
         full_payload = {'key': API_TOKEN, 'id': game_id}

--- a/cogs/game_cmd.py
+++ b/cogs/game_cmd.py
@@ -61,7 +61,7 @@ class game_cmd(commands.Cog):
 
         no_results_embed = discord.Embed(
             title=":wastebasket: No Results",
-            description=f"{itad_name} could not find a game with title `{title}`. Please try again.\n\n The API is very finnicky; special characters, punctuation, and full-series declaration are typically necessary.\n\n For example: `Skyrim` will not turn up results, but `The Elder Scrolls V: Skyrim Special Edition` will.",
+            description=f"{itad_name} could not find a game with title `{title}`. Please try again.",
             color=discord.Color.purple()
         )
 


### PR DESCRIPTION
Turns out, I just needed to swap out endpoint `/games/lookup/v1` with `/games/search/v1`. Returns all the same data I need for the API chain, minimal code changes needed, and it's *far* more reasonable with the search criteria. 

It's certainly nice when things line up so well.

Closes #169 (nice)