### PR TITLE
Rework classes for better error handling

### DIFF
--- a/classes/custom_exceptions.py
+++ b/classes/custom_exceptions.py
@@ -1,0 +1,5 @@
+class APIConnectionError(Exception):
+    pass
+
+class APIContentNotFoundError(Exception):
+    pass


### PR DESCRIPTION
While working to address #170 I went ahead and just did an overhaul of the relevant ITAD classes for better error handling and flow overall.

Work done:
- Added custom API error exception classes
- Reworked embeds for `/game` and logging in the cog to include API errors 
- Removed redundant `check_connection()` method in both ITAD classes which just caused `/game` to hit the API 2 extra times unnecessarily; new checks built into the API chaining handle this.

Given the fact that ITAD returned status code 403, which typically means unauthorized, when the site was down in it's entirety, it likely means that a 403 return is just how ITAD's API responds when their shit hits the fan. 

So, this PR closes #170, insofar as it is impossible to programmatically determine the difference between our API key being rejected and ITAD being down. Though echoing "our API key was rejected" isn't _untrue_, given if their API is down it technically means it rejects _all_ API keys.

Closes #170 