### PR TITLE
Remove necessity for admin_role_id and remove /user reporting if target is staff member or sysop

### DIFF
--- a/cogs/blacklist.py
+++ b/cogs/blacklist.py
@@ -51,8 +51,6 @@ class blacklist(commands.Cog):
     @app_commands.guilds(GUILD_ID)
     async def blacklist(self, interaction: discord.Interaction, options: app_commands.Choice[str], user: discord.Member):
 
-        
-        guild_admin_role = discord.utils.get(interaction.guild.roles, id=self.settings_data.get("admin_role_id"))
         guild_mod_role = discord.utils.get(interaction.guild.roles, id=self.settings_data.get("mod_role_id"))
         
         if options.value == "add":
@@ -62,7 +60,7 @@ class blacklist(commands.Cog):
                 logger.log(BLACKLIST, f"{interaction.user.name} ({interaction.user.id}) attempted to blacklist bot {user.name} ({user.id}).")
                 return
 
-            if guild_admin_role in user.roles or guild_mod_role in user.roles:
+            if user.guild_permissions.administrator or guild_mod_role in user.roles:
                 await interaction.response.send_message(f"Staff may not be blacklisted. If they warrant blacklisting they should not be staff members.", ephemeral=True)
                 logger.log(BLACKLIST, f"{interaction.user.name} ({interaction.user.id}) attempted to blacklist staff member {user.name} ({user.id}).")
                 return

--- a/cogs/user_cmds.py
+++ b/cogs/user_cmds.py
@@ -47,20 +47,6 @@ class user_cmds(commands.Cog):
         join_epoch = round(user.joined_at.timestamp()) #Get UNIX timestamp for when member joined the Discord.
         role_ids = [f"<@&{role.id}>" for role in user.roles if role.name != "@everyone"] #Get list of all role IDs the user has, excluding the default @@everyone role.
 
-        guild_sysop_role = discord.utils.get(interaction.guild.roles, id=self.settings_data.get("sysop_role_id"))
-        guild_admin_role = discord.utils.get(interaction.guild.roles, id=self.settings_data.get("admin_role_id"))
-        guild_mod_role = discord.utils.get(interaction.guild.roles, id=self.settings_data.get("mod_role_id"))
-
-        if guild_sysop_role in user.roles:
-            is_sysop = ":white_check_mark:"
-        else:
-            is_sysop= ":x:"
-
-        if guild_admin_role in user.roles or guild_mod_role in user.roles:
-            is_staff = ":white_check_mark:"
-        else:
-            is_staff = ":x:"
-
         if user.bot:
             bot_emoji = ":white_check_mark:"
         else:
@@ -77,8 +63,6 @@ class user_cmds(commands.Cog):
         embed.add_field(name="Global Name", value=user.global_name, inline=False)
         embed.add_field(name="Account Created", value=f"<t:{create_epoch}:f> (<t:{create_epoch}:R>)", inline=False)
         embed.add_field(name="Joined", value=f"<t:{join_epoch}:f> (<t:{join_epoch}:R>)", inline=False)
-        embed.add_field(name="Backend Operator?", value=is_sysop)
-        embed.add_field(name="Server Staff?", value=is_staff)
         embed.add_field(name="Bot?", value=bot_emoji)
         embed.add_field(name="Has Nitro?", value=premium_emoji)
 

--- a/data/variables_example.json
+++ b/data/variables_example.json
@@ -7,7 +7,6 @@
     "invite_alert_channel_id": 2345678901234567890,
     "sysop_role_id": 3456789012345678901,
     "mod_role_id": 4567890123456789012,
-    "admin_role_id": 5678901234567890123,
     "L_role_id": 7890123456789012345,
     "cooldown_exempt_roles": [
         9012345678901234567,


### PR DESCRIPTION
What it says on the tin.

Closes #175 and #174 