### PR TITLE
Refactor bot text and variables for genericity

### DIFF
--- a/cogs/rquote.py
+++ b/cogs/rquote.py
@@ -31,7 +31,7 @@ def custom_cooldown(interaction: discord.Interaction) -> app_commands.Cooldown |
     if not cog_instance.exempt_role_ids.isdisjoint(user_role_ids):
         return None
 
-    if interaction.channel_id == SETTINGS_DATA["out_of_context_channel_id"]:
+    if interaction.channel_id == SETTINGS_DATA["quotes_channel_id"]:
         return None
 
     return app_commands.Cooldown(1, cog_instance.cooldown)
@@ -62,7 +62,7 @@ class rquote(commands.Cog):
 
     async def rquote(self, interaction: discord.Interaction):
 
-        ooc_channel_id = self.settings_data.get("out_of_context_channel_id")
+        ooc_channel_id = self.settings_data.get("quotes_channel_id")
         ooc_channel = self.bot.get_channel(ooc_channel_id)
 
         has_attachment = False

--- a/cogs/temp_role.py
+++ b/cogs/temp_role.py
@@ -60,7 +60,7 @@ class temp_role(commands.Cog):
         await interaction.response.defer(ephemeral=True)
 
         role = interaction.guild.get_role(int(roles))
-        general_chat = self.bot.get_channel(SETTINGS_DATA["based_chat_channel_id"])
+        general_chat = self.bot.get_channel(SETTINGS_DATA["general_chat_channel_id"])
         timestamp_equation = datetime.datetime.now() + timedelta(hours=length)
         timestamp = timestamp_equation.replace(microsecond=0)
         timestamp_fancy = timestamp.strftime("%B %d, %Y %H:%M")

--- a/cogs/user_cmds.py
+++ b/cogs/user_cmds.py
@@ -142,7 +142,7 @@ class user_cmds(commands.Cog):
 
 # --- COMMAND: /info ---
 
-    @app_commands.command(name="info", description="Quick access to EDC relevant information.")
+    @app_commands.command(name="info", description="Quick access to community relevant information.")
     @app_commands.check(check_permissions)
     @app_commands.guilds(GUILD_ID)
     @app_commands.choices(options = [
@@ -156,10 +156,10 @@ class user_cmds(commands.Cog):
 
         if options.value == "links":
 
-            links_list = self.settings_data.get("edc_links", {})
+            links_list = self.settings_data.get("links", {})
 
             embed = discord.Embed(
-                title="Endurance Coalition Links",
+                title=f"{interaction.guild.name} Links",
                 color=discord.Color.purple()
             )
 
@@ -176,13 +176,13 @@ class user_cmds(commands.Cog):
 
         if options.value == "ports":
 
-            ports_list = self.settings_data.get("edc_ports", {})
-            edc_ip = self.settings_data.get("edc_ip")
-            edc_url = self.settings_data.get("edc_url")
+            ports_list = self.settings_data.get("ports", {})
+            ip = self.settings_data.get("ip")
+            url = self.settings_data.get("url")
 
             embed = discord.Embed(
-                title="Endurance Coalition IP Addresses",
-                description=f"Most games should accept `{edc_url}` as our IP address. Just append the port to the end like usual.\n\n If for some reason that does not work, our *raw* IP is `{edc_ip}`.",
+                title=f"{interaction.guild.name} IP Addresses",
+                description=f"Most games should accept `{url}` as our IP address. Just append the port to the end like usual.\n\n If for some reason that does not work, our *raw* IP is `{ip}`.",
                 color=discord.Color.blue()
             )
 

--- a/data/variables_example.json
+++ b/data/variables_example.json
@@ -2,9 +2,9 @@
     "repo": "https://github.com/dummyuser/dummyrepo",
     "docs": "https://myawesomedocumentationsite.org",
     "version": "2.0-beta",
-    "out_of_context_channel_id": 9876543210987654321,
+    "quotes_channel_id": 9876543210987654321,
     "alert_channel_id": 1234567890123456789,
-    "based_chat_channel_id": 2345678901234567890,
+    "general_chat_channel_id": 2345678901234567890,
     "invite_alert_channel_id": 2345678901234567890,
     "sysop_role_id": 3456789012345678901,
     "mod_role_id": 4567890123456789012,
@@ -13,15 +13,15 @@
         9012345678901234567,
         1023456789012345678
     ],
-    "edc_links": {
+    "links": {
         "https://dummygaming.org": "Dummy Gaming Main Site",
         "https://wiki.dummygaming.org": "Dummy Gaming Wiki Archive",
         "https://foundryvtt.dummygaming.org": "Virtual Tabletop for Pretend Adventures",
         "https://127.0.0.1:8080": "Localhost Development Port",
         "https://github.com/dummyuser/dummyrepo": "DummyBot GitHub Source"
     },
-    "edc_ip": "192.168.1.100",
-    "edc_url": "google.com",
+    "ip": "192.168.1.100",
+    "url": "google.com",
     "rquote_cooldown_in_seconds": 1800,
     "game_cooldown_in_seconds": 600,
     "game_num_uses_before_cooldown": 5,
@@ -32,7 +32,7 @@
     "bibleq_min_of_day": 0,
     "log_new_day_hour_utc": 0,
     "rquote_regex": "[\"](.+?)[\"]",
-    "edc_ports": {
+    "ports": {
         "Dummy Game Alpha": 1234,
         "Dummy Game Beta": 5678,
         "Dummy Game Gamma": 9012,

--- a/listeners/alert_detect.py
+++ b/listeners/alert_detect.py
@@ -39,7 +39,7 @@ class alert_detect(commands.Cog):
             await message.delete()
             embed = discord.Embed(
                 title="⚙️ Having an issue? Use `/alert`!", 
-                description="An **automated filter** has detected that a recent ping was made to systems operators in relation to an issue with EDC services.\n\n The preferred method of reporting a service being down is `/alert`.",
+                description="An **automated filter** has detected that a recent ping was made to systems operators in relation to an issue with community services.\n\n The preferred method of reporting a service being down is `/alert`.",
                 color=8650752
             )
             logger.info(f"{message.author.name} ({message.author.id}) triggered the /alert filter. Content: [{message.content}]")

--- a/listeners/member_monitor.py
+++ b/listeners/member_monitor.py
@@ -35,7 +35,7 @@ class member_monitor(commands.Cog):
 
                 embed = discord.Embed(
                     title=":rotating_light: Member Monitor Triggered",
-                    description=f"""`{name}` ({member.id}) joined the server. Upon inspection the user was found on the `member_monitor` table with the `{level}` level. As a result, they have been banned from EDC preemptively.
+                    description=f"""`{name}` ({member.id}) joined the server. Upon inspection the user was found on the `member_monitor` table with the `{level}` level. As a result, they have been banned from the server preemptively.
                     \n\n <@{mod_id}> added `{name}` to the monitor on <t:{timestamp}:f> with the reason shown below. Please speak with them for further details.
                     \n\n **This individual must be removed from the `member_monitor` table before unbanning**. They will simply be re-banned otherwise.""",
                     color=15086336

--- a/tasks/bible_daily.py
+++ b/tasks/bible_daily.py
@@ -26,8 +26,8 @@ class bible_daily(commands.Cog):
     async def daily_bible_quote(self):
         await self.bot.wait_until_ready()
 
-        based_chat_channel = self.bot.get_channel(self.settings_data.get("based_chat_channel_id"))
-        ooc_channel = self.bot.get_channel(self.settings_data.get("out_of_context_channel_id"))
+        general_chat_channel = self.bot.get_channel(self.settings_data.get("general_chat_channel_id"))
+        ooc_channel = self.bot.get_channel(self.settings_data.get("quotes_channel_id"))
         random_gospel = random.choice(self.misc_data["bible_gospels"])
         random_opener = random.choice(self.misc_data["daily_bible_openers"])
 
@@ -68,9 +68,9 @@ class bible_daily(commands.Cog):
         if selected_msg.attachments:
             embed.set_image(url=selected_msg.attachments[0].url)
 
-        await based_chat_channel.send(content=f"# ✝️ Bible Quote of the Day\n\n:palms_up_together: {random_opener}", embed=embed)
+        await general_chat_channel.send(content=f"# ✝️ Bible Quote of the Day\n\n:palms_up_together: {random_opener}", embed=embed)
         logger.info("Daily bible quote sent.")
-        logger.debug(f"Daily bible quote sent. Channel: [#{based_chat_channel.name} ({based_chat_channel.id})]. Dated: [{selected_msg.created_at.strftime("%B %d, %Y")}]. Opener: [{random_opener}]. Gospel: [{random_gospel}]. Content: [{formatted_quote}].")
+        logger.debug(f"Daily bible quote sent. Channel: [#{general_chat_channel.name} ({general_chat_channel.id})]. Dated: [{selected_msg.created_at.strftime("%B %d, %Y")}]. Opener: [{random_opener}]. Gospel: [{random_gospel}]. Content: [{formatted_quote}].")
 
     @daily_bible_quote.before_loop
     async def before_daily_bible_quote(self):


### PR DESCRIPTION
Variety of variables renamed for genericity:

- `out_of_context_channel_id` -> `quotes_channel_id`
- `based_chat_channel_id` -> `general_chat_channel_id`
- `edc_links` -> `links`
- `edc_ip` -> `ip`
- `edc_url` -> `url`
- `edc_ports` -> `ports`

Also replaced instances of `Endurance Coalition` or `EDC` throughout the bot with either a more generic term (e.g `community`) or with dynamic generation (e.g `{interaction.guild.name}`). Single exception for `/about` and `README.md` as the text correctly dictates that the bot was originally created for EDC.

Closes #187 