### PR TITLE
Make excluding certain text in /log more efficient and configurable

### DIFF
--- a/cogs/user_cmds.py
+++ b/cogs/user_cmds.py
@@ -236,17 +236,7 @@ class user_cmds(commands.Cog):
 
         chosen_lines = [
             line for line in reversed(list(open(log_file)))
-                if not re.search(r"Loaded", line)
-                and
-                not re.search(r"^---", line)
-                and
-                not re.search(r"Synced", line)
-                and
-                not re.search(r"Hello, world!", line)
-                and
-                not re.search(r":INFO:discord.client: logging in using static token", line)
-                and 
-                not re.search(r"PyNaCl is not installed", line)
+                if not any(re.search(text, line) for text in SETTINGS_DATA["log_text_exclude"])
         ]
 
         if sum(len(i) for i in chosen_lines[0:lines]) > 4096:

--- a/data/variables_example.json
+++ b/data/variables_example.json
@@ -48,6 +48,12 @@
     "disabled_cmds": [
         "YOUR_COMMAND_HERE"
     ],
+    "log_text_exclude": [
+        "Loaded",
+        "^---",
+        "Synced",
+        "Hello, world!"
+    ],
     "rquote_themes": {
         "hr": {
             "title": "💼 HR Office of EDC, Inc.",


### PR DESCRIPTION
Replaced the `if not... and not` chain with a more efficient use of `any()` with a generator instead. While not in the original issue, because why not, I've also made the list of text to exclude configurable now.

Closes #195 