### PR TITLE
Channel linking

### DIFF
--- a/classes/db_channel_link_handler.py
+++ b/classes/db_channel_link_handler.py
@@ -1,0 +1,78 @@
+import sqlite3
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import logging
+import datetime
+from datetime import datetime
+
+logger = logging.getLogger("endurabot." + __name__)
+
+
+class DBChannelLink:
+    def __init__(self):
+        self.connection = sqlite3.connect("endurabot.db")
+        self.cursor = self.connection.cursor()
+        check_if_table_exists = """CREATE TABLE IF NOT EXISTS channel_link(channel_link_id INTEGER PRIMARY KEY AUTOINCREMENT, text_channel_id TEXT, voice_channel_id TEXT)"""
+        self.cursor.execute(check_if_table_exists)
+        self.connection.commit()
+
+    def check_status(self, id):
+
+        id = str(id)
+
+        self.cursor.execute("SELECT text_channel_id FROM channel_link")
+        tuple = self.cursor.fetchall()
+        list = [ints[0] for ints in tuple]
+
+        if id in list:
+            return True
+
+        self.cursor.execute("SELECT voice_channel_id FROM channel_link")
+        tuple2 = self.cursor.fetchall()
+        list2 = [ints[0] for ints in tuple2]
+
+        if id in list2:
+            return True
+
+        return False
+        
+    def add_link(self, text_id, voice_id):
+
+        if self.check_status(text_id) == True:
+            raise ValueError("Link already exists for text channel.")
+
+        if self.check_status(voice_id) == True:
+            raise ValueError("Link already exists for voice channel.")
+
+        self.cursor.execute("INSERT INTO channel_link(text_channel_id, voice_channel_id) VALUES (?, ?)", (text_id, voice_id,))
+        self.connection.commit()
+
+    def remove_link(self, key):
+
+        self.cursor.execute(f"DELETE FROM channel_link WHERE channel_link_id = ?", (key,))
+        self.connection.commit()
+
+    def get_text_id(self, voice_id):
+
+        voice_id = str(voice_id)
+
+        self.cursor.execute("SELECT text_channel_id FROM channel_link WHERE voice_channel_id = ?", (voice_id,))
+        result = self.cursor.fetchone()
+        return result[0]
+
+    def get_links(self):
+        self.cursor.execute("SELECT channel_link_id, voice_channel_id, text_channel_id FROM channel_link")
+        result = self.cursor.fetchall()
+        return result
+
+    def get_links_by_key(self, key):
+        self.cursor.execute("SELECT voice_channel_id, text_channel_id FROM channel_link WHERE channel_link_id = ?", (key,))
+        result = self.cursor.fetchall()
+
+        if not result:
+            raise ValueError("No link found for provided ID.")
+
+        return result
+

--- a/cogs/channel_link.py
+++ b/cogs/channel_link.py
@@ -1,0 +1,113 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import discord
+from discord.ext import commands
+from discord import app_commands, AllowedMentions
+import logging
+from utils.config_loader import SETTINGS_DATA
+from utils.logging_setup import UNAUTHORIZED
+from utils.permissions_checker import check_permissions
+from classes.db_channel_link_handler import DBChannelLink
+
+logger = logging.getLogger('endurabot.' + __name__)
+
+GUILD_ID = int(os.getenv('guild'))
+
+class channel_link_cog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+    
+        self.default_allowed_mentions = AllowedMentions(
+                everyone=False,
+                users=True, 
+                roles=True      
+            )
+
+    # --- COMMAND: /cl-list ---
+
+    @app_commands.command(name="cl-list", description="List the channels that are linked together.")
+    @app_commands.check(check_permissions)
+    @app_commands.guilds(GUILD_ID)
+    async def cllist(self, interaction: discord.Interaction):
+        
+        channel_link = DBChannelLink()
+
+        links = channel_link.get_links()
+        links_strings = []
+
+        for key, voice, text in links:
+            links_strings.append(f"- <#{voice}> :link: <#{text}> (ID: {key})")
+
+        links_fancy = '\n'.join(links_strings)
+
+        embed = discord.Embed(
+            title = "Linked Channels",
+            description = links_fancy,
+            color = discord.Color.purple()
+        )
+
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+        logger.info(f"{interaction.user.name} ({interaction.user.id}) generated a list of linked channels.")
+
+
+    # --- COMMAND: /cl-add ---
+
+    @app_commands.command(name="cl-add", description="Link a voice and text channel together.")
+    @app_commands.check(check_permissions)
+    @app_commands.describe(
+        voice_channel = "Discord ID of the voice channel to link.",
+        text_channel = "Discord ID of the text channel to link."
+    )
+    @app_commands.guilds(GUILD_ID)
+    async def cladd(self, interaction: discord.Interaction, voice_channel: str, text_channel: str):
+        
+        channel_link = DBChannelLink()
+
+        if self.bot.get_channel(int(text_channel)) == None or self.bot.get_channel(int(voice_channel)) == None:
+            await interaction.response.send_message("One of the IDs provided is not a channel ID. Please try again.", ephemeral=True)
+            logger.error(f"{interaction.user.name} ({interaction.user.id}) attempted to LINK channels but one of them was not a channel ID.")
+
+        txt_channel = self.bot.get_channel(int(text_channel))
+        vc_channel = self.bot.get_channel(int(voice_channel))
+
+        try:
+            channel_link.add_link(text_channel, voice_channel)
+        except ValueError as e:
+            await interaction.response.send_message(e, ephemeral=True)
+            logger.error(f"{interaction.user.name} ({interaction.user.id}) got an error when trying to LINK #{vc_channel.name} ({vc_channel.id}) and #{txt_channel.name} ({txt_channel.id}): [{e}]")
+
+        await interaction.response.send_message(f"**Success**: <#{vc_channel.id}> :link: <#{txt_channel.id}>", ephemeral=True)
+        logger.info(f"{interaction.user.name} ({interaction.user.id}) linked #{vc_channel.name} ({vc_channel.id}) to #{txt_channel.name} ({txt_channel.id})")
+
+    # --- COMMAND: /cl-remove ---
+
+    @app_commands.command(name="cl-remove", description="Remove the link between a voice and text channel.")
+    @app_commands.check(check_permissions)
+    @app_commands.guilds(GUILD_ID)
+    async def clremove(self, interaction: discord.Interaction, id: str):
+        
+        channel_link = DBChannelLink()
+
+        try:
+            channel_link.get_links_by_key(id)
+        except ValueError as e:
+            await interaction.response.send_message(e, ephemeral=True)
+            logger.error(f"{interaction.user.name} ({interaction.user.id}) got an error when to delete a link. Error: [{e}]")
+        
+        get_channels = channel_link.get_links_by_key(id)
+
+        for voice, text in get_channels:
+            txt_channel = self.bot.get_channel(int(text))
+            vc_channel = self.bot.get_channel(int(voice))
+
+        channel_link.remove_link(id)
+
+        await interaction.response.send_message(f"**Success**: <#{vc_channel.id}> :broken_chain: <#{txt_channel.id}>.", ephemeral=True)
+        logger.info(f"{interaction.user.name} ({interaction.user.id}) remmoved the link between #{vc_channel.name} ({vc_channel.id}) and #{txt_channel.name} ({txt_channel.id}).")
+
+
+async def setup(bot):
+    await bot.add_cog(channel_link_cog(bot))

--- a/listeners/channel_link.py
+++ b/listeners/channel_link.py
@@ -1,0 +1,63 @@
+import discord
+from discord.ext import commands
+from discord import AllowedMentions
+import logging
+import random
+from classes.db_channel_link_handler import DBChannelLink
+
+channel_link = DBChannelLink()
+
+logger = logging.getLogger('endurabot.' + __name__)
+
+class channel_link_listener(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot     
+    
+        self.default_allowed_mentions = AllowedMentions(
+                everyone=False,
+                users=True, 
+                roles=True      
+            )
+
+    @commands.Cog.listener()
+    async def on_voice_state_update(self, member, before, after):
+        
+        # Initiate logic if user joins a linked channel
+        if not after.channel == None and channel_link.check_status(after.channel.id) == True:
+        
+            txt_channel_id = channel_link.get_text_id(after.channel.id)
+            txt_channel = self.bot.get_channel(int(txt_channel_id))
+
+            if member.guild_permissions.administrator:
+                logger.debug(f"{member.name} ({member.id}) joined VC {after.channel.name} linked to #{txt_channel.name}. {member.name} is an administrator. Nothing to do.")
+                return
+
+            # If the user already has a role that can see the linked channel, do nothing.
+            for role in member.roles:
+                perms = txt_channel.permissions_for(role)
+
+                if perms.read_messages:
+                    logger.debug(f"{member.name} ({member.id}) joined VC {after.channel.name} linked to #{txt_channel.name}. {member.name} has role [{role}] which grants read permissions. Nothing to do.")
+                    return
+
+            # If the user still has overwrites in the channel, do nothing.
+            if member in txt_channel.overwrites:
+                logger.debug(f"{member.name} ({member.id}) joined VC {after.channel.name} linked to #{txt_channel.name}. {member.name} already has overwrites. Nothing to do.")
+                return
+
+            # Give them read permissions.
+            await txt_channel.set_permissions(member, read_messages=True)
+            logger.debug(f"{member.name} ({member.id}) joined VC {after.channel.name} linked to #{txt_channel.name}. Read permissions granted.")
+
+        # If the user moved from another channel or left a channel, and they have overwrites, strip them.
+        if not before.channel == None and channel_link.check_status(before.channel.id) == True:
+            before_txt_channel_id = channel_link.get_text_id(before.channel.id)
+            before_txt_channel = self.bot.get_channel(int(before_txt_channel_id))
+
+            if member in before_txt_channel.overwrites:
+                await before_txt_channel.set_permissions(member, overwrite=None)
+                logger.debug(f"{member.name} ({member.id}) left VC {before.channel.name} linked to #{before_txt_channel.name}. Read permissions revoked.")
+        
+
+async def setup(bot):
+    await bot.add_cog(channel_link_listener(bot))


### PR DESCRIPTION
This PR introduces _channel linking_; the linking of voice and text channels together wherein anytime a member joins a voice channel they are automatically given read permissions for the linked text channel. This permission is then revoked upon leaving the channel.

Because all voice channel changes occur under the same event in Discord - `on_voice_state_update` - this occurs in _any_ situation where a person is leaving or exiting a channel. The method that causes an update to a voice state is not relevant.

I've confirmed that this feature functions as intended in the following scenarios:

- [x] Admins/mods moving people
- [x] Joining an event auto puts you into its channel
- [x] Users being disconnected
- [x] Users being timed out

This feature comes with 3 new commands:
- `/cl-add`: Link a text and voice channel together.
- `/cl-remove`: Self-explanatory.
- `/cl-list`: List the linked channels.

Closes #210 