### PR TITLE
Seperate /rquote debug logging to own file

### DIFF
--- a/cogs/rquote.py
+++ b/cogs/rquote.py
@@ -11,7 +11,7 @@ import random
 import re
 import logging
 from utils.config_loader import SETTINGS_DATA, MISC_DATA
-from utils.logging_setup import COOLDOWN, UNAUTHORIZED
+from utils.logging_setup import COOLDOWN, UNAUTHORIZED, RQUOTE
 from utils.permissions_checker import check_permissions
 from classes.db_rquote_used_handler import RquoteUsed
 
@@ -125,7 +125,7 @@ class rquote(commands.Cog):
 
         await interaction.response.send_message(embed=embed)
         logger.info(f"{interaction.user.name} ({interaction.user.id}) generated a random quote in #{interaction.channel.name} ({interaction.channel.id}).")
-        logger.debug(f"{interaction.user.name} ({interaction.user.id}) generated a random quote. Channel: [#{interaction.channel.name} ({interaction.channel.id})]. Dated: [{selected_msg.created_at.strftime("%B %d, %Y")}]. Theme: [{selected_theme_data["title"]}]. Opener: [{random_opener}]. Content: [{formatted_quote}]. Attachment: [{has_attachment}].")
+        logger.log(RQUOTE, f"{interaction.user.name} ({interaction.user.id}) generated a random quote. Channel: [#{interaction.channel.name} ({interaction.channel.id})]. Dated: [{selected_msg.created_at.strftime("%B %d, %Y")}]. Theme: [{selected_theme_data["title"]}]. Opener: [{random_opener}]. Shown Content: [{formatted_quote}]. Full Content: [{selected_msg.content}] Submitter: [{selected_msg.author} ({selected_msg.author.id})] Attachment: [{has_attachment}].")
 
     @rquote.error
     async def rquote_error(self, interaction: discord.Interaction, error: app_commands.AppCommandError):
@@ -197,7 +197,7 @@ class rquote(commands.Cog):
             if has_attachment == True:
                 embed2.set_image(url=selected_msg.attachments[0].url)
 
-            logger.debug(f"{interaction.user.name} ({interaction.user.id}) debugged a message. Verdict: [❌]. Dated: [{selected_msg.created_at.strftime("%B %d, %Y")}]. Message ID: [{selected_msg.id}]. Channel ID: [{channel_id}]. Author: [{selected_msg.author}]. Raw Content: [{selected_msg.content}]. Filtered Content: [{formatted_quote}]. Attachment: [{has_attachment}].")
+            logger.log(RQUOTE, f"{interaction.user.name} ({interaction.user.id}) debugged a message. Verdict: [❌]. Dated: [{selected_msg.created_at.strftime("%B %d, %Y")}]. Message ID: [{selected_msg.id}]. Channel ID: [{channel_id}]. Author: [{selected_msg.author} ({selected_msg.author.id})]. Raw Content: [{selected_msg.content}]. Filtered Content: [{formatted_quote}]. Attachment: [{has_attachment}].")
             await interaction.response.send_message(embeds=[embed1, embed2], ephemeral=True)
 
         # -- Phase 4: If message WOULD be selected, execute /rquote as normal but with the debugging embed too
@@ -235,7 +235,7 @@ class rquote(commands.Cog):
             if has_attachment == True:
                 embed1.set_image(url=selected_msg.attachments[0].url)
 
-            logger.debug(f"{interaction.user.name} ({interaction.user.id}) debugged a message. Verdict: [✅]. Dated: [{selected_msg.created_at.strftime("%B %d, %Y")}]. Message ID: [{selected_msg.id}]. Channel ID: [{channel_id}]. Author: [{selected_msg.author}]. Theme: [{selected_theme_data["opener_key"]}]. Opener: [{random_opener}]. Raw Content: [{selected_msg.content}]. Filtered Content: [{formatted_quote}]. Attachment: [{has_attachment}].")
+            logger.log(RQUOTE, f"{interaction.user.name} ({interaction.user.id}) debugged a message. Verdict: [✅]. Dated: [{selected_msg.created_at.strftime("%B %d, %Y")}]. Message ID: [{selected_msg.id}]. Channel ID: [{channel_id}]. Author: [{selected_msg.author} ({selected_msg.author.id})]. Theme: [{selected_theme_data["opener_key"]}]. Opener: [{random_opener}]. Raw Content: [{selected_msg.content}]. Filtered Content: [{formatted_quote}]. Attachment: [{has_attachment}].")
             await interaction.response.send_message(embeds=[embed1, embed2], ephemeral=True)
 
 async def setup(bot):

--- a/utils/logging_setup.py
+++ b/utils/logging_setup.py
@@ -18,10 +18,17 @@ logging.addLevelName(BOOT, 'BOOT')
 INVITES = 39
 logging.addLevelName(INVITES, 'INVITES')
 
+RQUOTE = 15
+logging.addLevelName(RQUOTE, 'RQUOTE')
+
 # Custom filter so that debug messages go to their own file.
 class DebugOnlyFilter(logging.Filter):
     def filter(self, record):
         return record.levelno == logging.DEBUG
+
+class RquoteOnlyFilter(logging.Filter):
+    def filter(self, record):
+        return record.levelno == 15
 
 # Custom filter so that `discord.gateway` does't log anything below the WARNING level.
 logging.getLogger("discord.gateway").setLevel(logging.WARNING + 1)
@@ -65,6 +72,13 @@ def configure_logging():
     file_handler_debug.addFilter(DebugOnlyFilter()) # Apply the debug-only filter
     logger.addHandler(file_handler_debug)
     discord_logger.addHandler(file_handler_debug)
+
+    file_handler_rquote = logging.FileHandler(filename="logs/endurabot_rquote.log", encoding='utf-8', mode='a')
+    file_handler_rquote.setLevel(logging.DEBUG)
+    file_handler_rquote.setFormatter(standard_formatter)
+    file_handler_rquote.addFilter(RquoteOnlyFilter())
+    logger.addHandler(file_handler_rquote)
+    discord_logger.addHandler(file_handler_rquote)
 
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setLevel(logging.DEBUG)


### PR DESCRIPTION
The verbose `/rquote` logging has been moved out of `endurabot_debug.log` and sent to it's own `endurabot_rquote.log` file. I have also expanded the logging to include the non-filtered content of the message and the person who sent the message.

Closes #212 